### PR TITLE
answerがなくてもindexのエラーを出さないようした。

### DIFF
--- a/app/views/admin/questions/index.html.haml
+++ b/app/views/admin/questions/index.html.haml
@@ -11,3 +11,5 @@
     = question.feature
     |
     %p
+  = link_to "質問登録", new_admin_question_path, class: "color-red01"
+

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -11,8 +11,8 @@
         / チャートに関する記述ここから
         #status-wrapper
           - pInde = 0 & pExec = 0 & pCrea = 0 & pPlan = 0 & pTeam = 0 & pComm = 0
-          - if @past_independent.present?
-            - @past_independence.zip(@past_execution, @past_creativity, @past_planning, @past_teamwork, @past_communication).each do | past_independence, past_execution, past_creativity, past_planning, past_teamwork, past_communication |
+          - @past_independence.zip(@past_execution, @past_creativity, @past_planning, @past_teamwork, @past_communication).each do | past_independence, past_execution, past_creativity, past_planning, past_teamwork, past_communication |
+            - if @answer.present?
               - pInde += past_independence.answer.rank
               - pExec += past_execution.answer.rank
               - pCrea += past_creativity.answer.rank


### PR DESCRIPTION
# What
answerが空の場合でもchart.jsが表示できるようにした。

# Why
home#indexのviewにてchart.jsがエラーを起こさないようにするため。

※なお、上記と関係ない記述ですが、question/indexですぐに次の質問が投稿できるようにquestion/newへのリンクを追記しています。